### PR TITLE
fix: add try-catch block to avoid breaking on mixin's parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -217,10 +217,18 @@ function parseSymbols(text: string) {
 				continue;
 			}
 
+			let parameters: IVariable[] = [];
+
+			try {
+				parameters = makeMixinParameters(params, paramsOffset);
+			} catch (error) {
+				// console.warn(error.message);
+			}
+
 			if (name && params) {
 				mixins.push({
 					name: name.trim(),
-					parameters: makeMixinParameters(params, paramsOffset),
+					parameters,
 					offset
 				});
 			} else {


### PR DESCRIPTION
Before there is a better approach. I just want to add the `try-catch` block to avoid [these cases](https://github.com/mrmlnc/less-symbols-parser/issues/7#issuecomment-901853580). Otherwise, only the `try-catch` block in vscode-less will handle this and it would break all the intelligence of this file, include other symbols like variables, imports, etc...

